### PR TITLE
[#2] feat: 대기열 및 등록 API 구현

### DIFF
--- a/src/main/java/com/kbo/config/RedisConfig.java
+++ b/src/main/java/com/kbo/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -22,11 +23,13 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+		Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(Object.class);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(serializer);
 		return redisTemplate;
 	}
 }

--- a/src/main/java/com/kbo/queue/constant/QueueKeyPrefix.java
+++ b/src/main/java/com/kbo/queue/constant/QueueKeyPrefix.java
@@ -1,0 +1,20 @@
+package com.kbo.queue.constant;
+
+import java.util.Arrays;
+
+public enum QueueKeyPrefix {
+	QUEUE("queue:"),
+	TTL("queue:ttl:");
+
+	private final String prefix;
+
+	QueueKeyPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public String format(Object... values) {
+		return prefix + String.join(":", Arrays.stream(values)
+			.map(Object::toString)
+			.toArray(String[]::new));
+	}
+}

--- a/src/main/java/com/kbo/queue/controller/QueueController.java
+++ b/src/main/java/com/kbo/queue/controller/QueueController.java
@@ -1,0 +1,25 @@
+package com.kbo.queue.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kbo.queue.controller.request.QueueRequest;
+import com.kbo.queue.controller.response.QueueResponse;
+import com.kbo.queue.service.QueueService;
+
+@RestController
+@RequestMapping("/queue")
+public class QueueController {
+	private final QueueService queueService;
+
+	public QueueController(QueueService queueService) {
+		this.queueService = queueService;
+	}
+
+	@PostMapping("/join")
+	public QueueResponse join(@RequestBody QueueRequest queueRequest) {
+		return queueService.join(queueRequest.gameId(), queueRequest.userId());
+	}
+}

--- a/src/main/java/com/kbo/queue/controller/request/QueueRequest.java
+++ b/src/main/java/com/kbo/queue/controller/request/QueueRequest.java
@@ -1,0 +1,6 @@
+package com.kbo.queue.controller.request;
+
+public record QueueRequest(
+	long gameId, long userId
+) {
+}

--- a/src/main/java/com/kbo/queue/controller/response/QueueResponse.java
+++ b/src/main/java/com/kbo/queue/controller/response/QueueResponse.java
@@ -1,0 +1,8 @@
+package com.kbo.queue.controller.response;
+
+public record QueueResponse(
+	long currentRank,
+	long queueSize,
+	boolean isAccepted
+) {
+}

--- a/src/main/java/com/kbo/queue/repository/QueueRepository.java
+++ b/src/main/java/com/kbo/queue/repository/QueueRepository.java
@@ -1,0 +1,35 @@
+package com.kbo.queue.repository;
+
+import static com.kbo.queue.constant.QueueKeyPrefix.*;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class QueueRepository {
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public QueueRepository(RedisTemplate<String, Object> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public void add(long gameId, long userId) {
+		redisTemplate.opsForZSet().add(QUEUE.format(gameId), userId, System.nanoTime());
+	}
+
+	public Long rank(long gameId, long userId) {
+		return redisTemplate.opsForZSet().rank(QUEUE.format(gameId), userId);
+	}
+
+	public Double score(long gameId, long userId) {
+		return redisTemplate.opsForZSet().score(QUEUE.format(gameId), userId);
+	}
+
+	public Long size(long gameId) {
+		return redisTemplate.opsForZSet().size(QUEUE.format(gameId));
+	}
+
+	public void remove(long gameId, long userId) {
+		redisTemplate.opsForZSet().remove(QUEUE.format(gameId), userId);
+	}
+}

--- a/src/main/java/com/kbo/queue/repository/QueueTtlRepository.java
+++ b/src/main/java/com/kbo/queue/repository/QueueTtlRepository.java
@@ -1,0 +1,29 @@
+package com.kbo.queue.repository;
+
+import static com.kbo.queue.constant.QueueKeyPrefix.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class QueueTtlRepository {
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public QueueTtlRepository(RedisTemplate<String, Object> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public void setExpire(long gameId, long userId, long ttlSeconds) {
+		redisTemplate.opsForValue().set(TTL.format(gameId, userId), userId, ttlSeconds, TimeUnit.SECONDS);
+	}
+
+	public boolean isExpired(long gameId, long userId) {
+		return redisTemplate.opsForValue().get(TTL.format(gameId, userId)) == null;
+	}
+
+	public void remove(long gameId, long userId) {
+		redisTemplate.delete(TTL.format(gameId, userId));
+	}
+}

--- a/src/main/java/com/kbo/queue/service/QueueService.java
+++ b/src/main/java/com/kbo/queue/service/QueueService.java
@@ -8,6 +8,8 @@ import com.kbo.queue.repository.QueueTtlRepository;
 
 @Service
 public class QueueService {
+	private static final long QUEUE_TTL_TIME_SECONDS = 30;
+
 	private final QueueRepository queueRepository;
 	private final QueueTtlRepository queueTtlRepository;
 
@@ -22,7 +24,7 @@ public class QueueService {
 		}
 
 		queueRepository.add(gameId, userId);
-		queueTtlRepository.setExpire(gameId, userId, 30);
+		queueTtlRepository.setExpire(gameId, userId, QUEUE_TTL_TIME_SECONDS);
 		return getPosition(gameId, userId);
 	}
 

--- a/src/main/java/com/kbo/queue/service/QueueService.java
+++ b/src/main/java/com/kbo/queue/service/QueueService.java
@@ -1,0 +1,38 @@
+package com.kbo.queue.service;
+
+import org.springframework.stereotype.Service;
+
+import com.kbo.queue.controller.response.QueueResponse;
+import com.kbo.queue.repository.QueueRepository;
+import com.kbo.queue.repository.QueueTtlRepository;
+
+@Service
+public class QueueService {
+	private final QueueRepository queueRepository;
+	private final QueueTtlRepository queueTtlRepository;
+
+	public QueueService(QueueRepository queueRepository, QueueTtlRepository queueTtlRepository) {
+		this.queueRepository = queueRepository;
+		this.queueTtlRepository = queueTtlRepository;
+	}
+
+	public QueueResponse join(long gameId, long userId) {
+		if (queueRepository.score(gameId, userId) != null) {
+			queueRepository.remove(gameId, userId);
+		}
+
+		queueRepository.add(gameId, userId);
+		queueTtlRepository.setExpire(gameId, userId, 30);
+		return getPosition(gameId, userId);
+	}
+
+	public QueueResponse getPosition(long gameId, long userId) {
+		Long rank = queueRepository.rank(gameId, userId);
+		if (rank == null) {
+			throw new IllegalArgumentException("User " + userId + " is not in the queue.");
+		}
+
+		long totalQueueSize = queueRepository.size(gameId);
+		return new QueueResponse(rank + 1, totalQueueSize, false);
+	}
+}

--- a/src/test/java/com/kbo/queue/repository/QueueRepositoryTest.java
+++ b/src/test/java/com/kbo/queue/repository/QueueRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.kbo.queue.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class QueueRepositoryTest {
+	@Autowired
+	private QueueRepository queueRepository;
+
+	private static final long GAME_ID = 1001L;
+	private static final long USER_ID_1 = 2001L;
+	private static final long USER_ID_2 = 2002L;
+
+	@BeforeEach
+	void setUp() {
+		queueRepository.remove(GAME_ID, USER_ID_1);
+		queueRepository.remove(GAME_ID, USER_ID_2);
+	}
+
+	@Test
+	void should_add_when_user() {
+		queueRepository.add(GAME_ID, USER_ID_1);
+
+		Long rank = queueRepository.rank(GAME_ID, USER_ID_1);
+		assertThat(rank).isNotNull();
+		assertThat(rank).isEqualTo(0);
+	}
+
+	@Test
+	void should_add_when_users() {
+		queueRepository.add(GAME_ID, USER_ID_1);
+		queueRepository.add(GAME_ID, USER_ID_2);
+
+		Long size = queueRepository.size(GAME_ID);
+		assertThat(size).isEqualTo(2);
+	}
+
+	@Test
+	void should_score_when_user() {
+		queueRepository.add(GAME_ID, USER_ID_1);
+
+		Double score = queueRepository.score(GAME_ID, USER_ID_1);
+		assertThat(score).isNotNull();
+	}
+}

--- a/src/test/java/com/kbo/queue/repository/QueueTtlRepositoryTest.java
+++ b/src/test/java/com/kbo/queue/repository/QueueTtlRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.kbo.queue.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class QueueTtlRepositoryTest {
+	@Autowired
+	private QueueTtlRepository queueTtlRepository;
+
+	private static final long GAME_ID = 1001L;
+	private static final long USER_ID = 2001L;
+
+	@BeforeEach
+	void setUp() {
+		queueTtlRepository.remove(GAME_ID, USER_ID);
+	}
+
+	@Test
+	void should_setExpire_when_user() {
+		queueTtlRepository.setExpire(GAME_ID, USER_ID, 300);
+
+		boolean expired = queueTtlRepository.isExpired(GAME_ID, USER_ID);
+
+		assertThat(expired).isFalse();
+	}
+
+	@Test
+	void should_isExpired_when_timeOut() throws InterruptedException {
+		queueTtlRepository.setExpire(GAME_ID, USER_ID, 3);
+		Thread.sleep(4000);
+
+		boolean expired = queueTtlRepository.isExpired(GAME_ID, USER_ID);
+
+		assertThat(expired).isTrue();
+	}
+}

--- a/src/test/java/com/kbo/queue/service/QueueServiceTest.java
+++ b/src/test/java/com/kbo/queue/service/QueueServiceTest.java
@@ -1,0 +1,63 @@
+package com.kbo.queue.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kbo.queue.controller.response.QueueResponse;
+import com.kbo.queue.repository.QueueRepository;
+import com.kbo.queue.repository.QueueTtlRepository;
+
+@ExtendWith(MockitoExtension.class)
+class QueueServiceTest {
+	@Mock
+	private QueueRepository queueRepository;
+
+	@Mock
+	private QueueTtlRepository queueTtlRepository;
+
+	@InjectMocks
+	private QueueService queueService;
+
+	private static final long GAME_ID = 1001L;
+	private static final long USER_ID = 2001L;
+	private static final long RANK = 0L;
+	private static final long SIZE = 1L;
+
+	@Test
+	void should_join_when_user() {
+		when(queueRepository.rank(GAME_ID, USER_ID)).thenReturn(RANK);
+		when(queueRepository.size(GAME_ID)).thenReturn(SIZE);
+
+		QueueResponse result = queueService.join(GAME_ID, USER_ID);
+
+		assertThat(result).isNotNull();
+		assertThat(result.currentRank()).isEqualTo(1L);
+		assertThat(result.queueSize()).isEqualTo(SIZE);
+
+		verify(queueRepository, times(1)).add(GAME_ID, USER_ID);
+		verify(queueTtlRepository, times(1)).setExpire(GAME_ID, USER_ID, 30);
+	}
+
+	@Test
+	void should_join_when_existsUser() {
+		when(queueRepository.score(GAME_ID, USER_ID)).thenReturn(1.1);
+		when(queueRepository.rank(GAME_ID, USER_ID)).thenReturn(RANK);
+		when(queueRepository.size(GAME_ID)).thenReturn(SIZE);
+
+		QueueResponse result = queueService.join(GAME_ID, USER_ID);
+
+		assertThat(result).isNotNull();
+		assertThat(result.currentRank()).isEqualTo(1L);
+		assertThat(result.queueSize()).isEqualTo(SIZE);
+
+		verify(queueRepository, times(1)).remove(GAME_ID, USER_ID);
+		verify(queueRepository, times(1)).add(GAME_ID, USER_ID);
+		verify(queueTtlRepository, times(1)).setExpire(GAME_ID, USER_ID, 30);
+	}
+}


### PR DESCRIPTION
## 작업 내용
1. 대기열 구현
    - Redis(Sorted Set, String) 사용
        - Sorted Set은 점수 기반 정렬이 가능하여 사용자 순서를 효율적으로 관리할 수 있음.
        - String은 TTL을 적용하여 만료된 사용자를 관리하는데 적합함.
        - 토큰 생성 및 반환은 대기열 이후 기능에서 고려하기로 함.
## 기술적 고려 사항
1. TTL 만료 후 대기열에서 사용자 자동 삭제 필요
    - TTL 만료로 인해 대기열에서 이탈한 사용자인지 판단할 수 있으나 Sorted Set에서 자동으로 삭제되지 않음.
    - 만료된 사용자가 제거되지 않을 경우, 불필요한 데이터가 지속적으로 누적되어 대기열 데이터의 무결성이 유지되지 않을 위험이 있음.