### PR TITLE
[#4] feat: 세션 만료 사용자 대기열 제거 기능 구현

### DIFF
--- a/src/main/java/com/kbo/config/RedisKeyExpirationConfig.java
+++ b/src/main/java/com/kbo/config/RedisKeyExpirationConfig.java
@@ -1,0 +1,16 @@
+package com.kbo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class RedisKeyExpirationConfig {
+	@Bean("keyExpirationConfig")
+	public RedisMessageListenerContainer keyExpirationConfig(RedisConnectionFactory connectionFactory) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		return container;
+	}
+}

--- a/src/main/java/com/kbo/queue/listener/QueueSessionExpiredListener.java
+++ b/src/main/java/com/kbo/queue/listener/QueueSessionExpiredListener.java
@@ -1,5 +1,7 @@
 package com.kbo.queue.listener;
 
+import static com.kbo.util.ValidatorUtil.*;
+
 import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
@@ -36,7 +38,7 @@ public class QueueSessionExpiredListener extends KeyExpirationEventMessageListen
 			return;
 		}
 
-		if (expiredKey.length() <= SESSION_PREFIX.length()) {
+		if (expiredKey.length() != SESSION_PREFIX.length()) {
 			log.error("Session key has no token: {}", expiredKey);
 			return;
 		}
@@ -67,7 +69,7 @@ public class QueueSessionExpiredListener extends KeyExpirationEventMessageListen
 		String userIdString = parts[2];
 		String nanoTimeString = parts[3];
 
-		if (randomString.length() != 8 || !randomString.matches("^[A-Za-z0-9]+$")) {
+		if (!isAlphanumeric8(randomString)) {
 			return false;
 		}
 

--- a/src/main/java/com/kbo/queue/listener/QueueSessionExpiredListener.java
+++ b/src/main/java/com/kbo/queue/listener/QueueSessionExpiredListener.java
@@ -1,0 +1,84 @@
+package com.kbo.queue.listener;
+
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+import com.kbo.queue.repository.QueueRepository;
+
+@Component
+public class QueueSessionExpiredListener extends KeyExpirationEventMessageListener {
+	private static final Logger log = LoggerFactory.getLogger(QueueSessionExpiredListener.class);
+	private final QueueRepository queueRepository;
+
+	private static final String SESSION_PREFIX = "queue:session:";
+
+	public QueueSessionExpiredListener(
+		@Qualifier("keyExpirationConfig") RedisMessageListenerContainer listenerContainer,
+		QueueRepository queueRepository
+	) {
+		super(listenerContainer);
+		this.queueRepository = queueRepository;
+	}
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		String expiredKey = new String(message.getBody(), StandardCharsets.UTF_8);
+		log.info("Queue session expired: {}", expiredKey);
+
+		if (!expiredKey.startsWith(SESSION_PREFIX)) {
+			return;
+		}
+
+		if (expiredKey.length() <= SESSION_PREFIX.length()) {
+			log.error("Session key has no token: {}", expiredKey);
+			return;
+		}
+
+		String token = expiredKey.substring(SESSION_PREFIX.length());
+
+		if (!isValidToken(token)) {
+			log.error("Invalid session token: {}", token);
+			return;
+		}
+
+		String[] tokenParts = token.split("-");
+		long gameId = Long.parseLong(tokenParts[1]);
+		long userId = Long.parseLong(tokenParts[2]);
+
+		queueRepository.remove(gameId, userId);
+	}
+
+	private boolean isValidToken(String token) {
+		String[] parts = token.split("-");
+
+		if (parts.length != 4) {
+			return false;
+		}
+
+		String randomString = parts[0];
+		String gameIdString = parts[1];
+		String userIdString = parts[2];
+		String nanoTimeString = parts[3];
+
+		if (randomString.length() != 8 || !randomString.matches("^[A-Za-z0-9]+$")) {
+			return false;
+		}
+
+		try {
+			Long.parseLong(gameIdString);
+			Long.parseLong(userIdString);
+			Long.parseLong(nanoTimeString);
+		} catch (NumberFormatException e) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/com/kbo/util/RegexPatterns.java
+++ b/src/main/java/com/kbo/util/RegexPatterns.java
@@ -1,0 +1,10 @@
+package com.kbo.util;
+
+import java.util.regex.Pattern;
+
+public class RegexPatterns {
+	public static final Pattern ALPHANUMERIC_8 = Pattern.compile("^[A-Za-z0-9]{8}$");
+
+	// 유틸 클래스이므로 생성자 private 처리
+	private RegexPatterns() {}
+}

--- a/src/main/java/com/kbo/util/ValidatorUtil.java
+++ b/src/main/java/com/kbo/util/ValidatorUtil.java
@@ -1,0 +1,9 @@
+package com.kbo.util;
+
+import static com.kbo.util.RegexPatterns.*;
+
+public class ValidatorUtil {
+	public static boolean isAlphanumeric8(String input) {
+		return input != null && ALPHANUMERIC_8.matcher(input).matches();
+	}
+}

--- a/src/test/java/com/kbo/queue/listener/QueueSessionExpiredListenerTest.java
+++ b/src/test/java/com/kbo/queue/listener/QueueSessionExpiredListenerTest.java
@@ -1,0 +1,97 @@
+package com.kbo.queue.listener;
+
+import static org.mockito.Mockito.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import com.kbo.queue.repository.QueueRepository;
+
+@ExtendWith(MockitoExtension.class)
+class QueueSessionExpiredListenerTest {
+	@Mock
+	private QueueRepository queueRepository;
+
+	@Mock
+	private RedisMessageListenerContainer container;
+
+	private QueueSessionExpiredListener listener;
+
+	@BeforeEach
+	void setUp() {
+		listener = new QueueSessionExpiredListener(container, queueRepository);
+	}
+
+	@Test
+	void should_prefix_when_invalid() {
+		String key = "invalid:session:abcD1234-1001-2001-123456789";
+		Message message = mock(Message.class);
+		when(message.getBody()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
+
+		listener.onMessage(message, null);
+
+		verifyNoInteractions(queueRepository);
+	}
+
+	@Test
+	void should_token_when_notExist() {
+		String key = "queue:session:";
+		Message message = mock(Message.class);
+		when(message.getBody()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
+
+		listener.onMessage(message, null);
+
+		verifyNoInteractions(queueRepository);
+	}
+
+	@Test
+	void should_token_when_isShort() {
+		String key = "queue:session:abcD1234-10";
+		Message message = mock(Message.class);
+		when(message.getBody()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
+
+		listener.onMessage(message, null);
+
+		verifyNoInteractions(queueRepository);
+	}
+
+	@Test
+	void should_gameId_when_invalidNumberFormat() {
+		String key = "queue:session:abcD1234-xyz-20-123456789";
+		Message message = mock(Message.class);
+		when(message.getBody()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
+
+		listener.onMessage(message, null);
+
+		verifyNoInteractions(queueRepository);
+	}
+
+	@Test
+	void should_randomString_when_invalid() {
+		String key = "queue:session:abc*1234-1001-2001-123456789";
+		Message message = mock(Message.class);
+		when(message.getBody()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
+
+		listener.onMessage(message, null);
+
+		verifyNoInteractions(queueRepository);
+	}
+
+	@Test
+	void should_remove_when_valid() {
+		String key = "queue:session:abcD1234-1001-2001-123456789";
+		Message message = mock(Message.class);
+		when(message.getBody()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
+
+		listener.onMessage(message, null);
+
+		verify(queueRepository, times(1)).remove(1001L, 2001L);
+	}
+}


### PR DESCRIPTION
## 작업 내용
1. 대기열 제거 기능 구현
    - Redis 이벤트 감지 기능 활용
        - 사용자 세션 만료 이벤트 감지.
        - 세션의 prefix 기반으로 유효성 검증 후 대기열에서 사용자 아이디 제거.
        - 토큰 구조 오류, 파싱 실패 등 예외 상황에 대한 검증 로직 추가.