### PR TITLE
[#15] feat: 대기열 세션 검증 기능 구현

### DIFF
--- a/src/main/java/com/kbo/config/WebConfig.java
+++ b/src/main/java/com/kbo/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.kbo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.kbo.config.interceptor.QueueSessionInterceptor;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+	private final QueueSessionInterceptor queueSessionInterceptor;
+
+	public WebConfig(QueueSessionInterceptor queueSessionInterceptor) {
+		this.queueSessionInterceptor = queueSessionInterceptor;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(queueSessionInterceptor)
+			.addPathPatterns("/queue/subscribe");
+	}
+}

--- a/src/main/java/com/kbo/config/interceptor/QueueSessionInterceptor.java
+++ b/src/main/java/com/kbo/config/interceptor/QueueSessionInterceptor.java
@@ -1,0 +1,45 @@
+package com.kbo.config.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.kbo.queue.controller.response.QueueSession;
+import com.kbo.queue.repository.QueueSessionRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class QueueSessionInterceptor implements HandlerInterceptor {
+	private final QueueSessionRepository queueSessionRepository;
+
+	public QueueSessionInterceptor(QueueSessionRepository queueSessionRepository) {
+		this.queueSessionRepository = queueSessionRepository;
+	}
+
+	@Override
+	public boolean preHandle(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		Object handler
+	) throws Exception {
+		String sessionToken = request.getHeader("X-Session-Token");
+
+		if (sessionToken == null || sessionToken.isEmpty()) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.getWriter().write("Missing Session-Token");
+			return false;
+		}
+
+		QueueSession queueSession = queueSessionRepository.getSession(sessionToken);
+		if (queueSession == null) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.getWriter().write("Invalid Session-Token");
+			return false;
+		}
+
+		request.setAttribute("sessionToken", sessionToken);
+
+		return true;
+	}
+}

--- a/src/main/java/com/kbo/config/interceptor/QueueSessionInterceptor.java
+++ b/src/main/java/com/kbo/config/interceptor/QueueSessionInterceptor.java
@@ -1,5 +1,7 @@
 package com.kbo.config.interceptor;
 
+import static com.kbo.queue.constant.SessionKey.*;
+
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -23,7 +25,7 @@ public class QueueSessionInterceptor implements HandlerInterceptor {
 		HttpServletResponse response,
 		Object handler
 	) throws Exception {
-		String sessionToken = request.getHeader("X-Session-Token");
+		String sessionToken = request.getHeader(SESSION_TOKEN_HEADER.getKey());
 
 		if (sessionToken == null || sessionToken.isEmpty()) {
 			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -38,7 +40,7 @@ public class QueueSessionInterceptor implements HandlerInterceptor {
 			return false;
 		}
 
-		request.setAttribute("sessionToken", sessionToken);
+		request.setAttribute(SESSION_TOKEN_ATTRIBUTE.getKey(), sessionToken);
 
 		return true;
 	}

--- a/src/main/java/com/kbo/queue/constant/SessionKey.java
+++ b/src/main/java/com/kbo/queue/constant/SessionKey.java
@@ -1,0 +1,16 @@
+package com.kbo.queue.constant;
+
+public enum SessionKey {
+	SESSION_TOKEN_ATTRIBUTE("sessionToken"),
+	SESSION_TOKEN_HEADER("X-Session-Token");
+
+	private final String key;
+
+	SessionKey(String key) {
+		this.key = key;
+	}
+
+	public String getKey() {
+		return key;
+	}
+}

--- a/src/main/java/com/kbo/queue/controller/QueueController.java
+++ b/src/main/java/com/kbo/queue/controller/QueueController.java
@@ -2,7 +2,6 @@ package com.kbo.queue.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +12,8 @@ import com.kbo.queue.controller.request.QueueRequest;
 import com.kbo.queue.controller.response.QueueSession;
 import com.kbo.queue.service.QueueService;
 import com.kbo.sse.service.SseService;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/queue")
@@ -30,8 +31,8 @@ public class QueueController {
 		return queueService.join(queueRequest.gameId(), queueRequest.userId());
 	}
 
-	@GetMapping(value = "/subscribe/{sessionToken}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-	public SseEmitter subscribe(@PathVariable("sessionToken") String sessionToken) {
-		return sseService.add(sessionToken);
+	@GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter subscribe(HttpServletRequest request) {
+		return sseService.add((String)request.getAttribute("sessionToken"));
 	}
 }

--- a/src/main/java/com/kbo/queue/controller/QueueController.java
+++ b/src/main/java/com/kbo/queue/controller/QueueController.java
@@ -1,5 +1,7 @@
 package com.kbo.queue.controller;
 
+import static com.kbo.queue.constant.SessionKey.*;
+
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,6 +35,6 @@ public class QueueController {
 
 	@GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public SseEmitter subscribe(HttpServletRequest request) {
-		return sseService.add((String)request.getAttribute("sessionToken"));
+		return sseService.add((String)request.getAttribute(SESSION_TOKEN_ATTRIBUTE.getKey()));
 	}
 }

--- a/src/test/java/com/kbo/config/interceptor/QueueSessionInterceptorTest.java
+++ b/src/test/java/com/kbo/config/interceptor/QueueSessionInterceptorTest.java
@@ -1,0 +1,68 @@
+package com.kbo.config.interceptor;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.kbo.fixture.QueueSessionFixture;
+import com.kbo.queue.repository.QueueSessionRepository;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class QueueSessionInterceptorTest {
+	@Mock
+	private QueueSessionRepository queueSessionRepository;
+
+	private QueueSessionInterceptor queueSessionInterceptor;
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+
+	private static final String SESSION_TOKEN = "session-token";
+
+	@BeforeEach
+	void setUp() {
+		queueSessionInterceptor = new QueueSessionInterceptor(queueSessionRepository);
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+	}
+
+	@Test
+	void should_token_when_missing() throws Exception {
+		boolean result = queueSessionInterceptor.preHandle(request, response, new Object());
+
+		assertThat(result).isFalse();
+		assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+		assertThat(response.getContentAsString()).contains("Missing Session-Token");
+	}
+
+	@Test
+	void should_token_when_invalid() throws Exception {
+		request.addHeader("X-Session-Token", SESSION_TOKEN);
+		when(queueSessionRepository.getSession(SESSION_TOKEN)).thenReturn(null);
+
+		boolean result = queueSessionInterceptor.preHandle(request, response, new Object());
+
+		assertThat(result).isFalse();
+		assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+		assertThat(response.getContentAsString()).contains("Invalid Session-Token");
+	}
+
+	@Test
+	void should_token_when_valid() throws Exception {
+		request.addHeader("X-Session-Token", SESSION_TOKEN);
+		when(queueSessionRepository.getSession(SESSION_TOKEN)).thenReturn(QueueSessionFixture.get(SESSION_TOKEN));
+
+		boolean result = queueSessionInterceptor.preHandle(request, response, new Object());
+
+		assertThat(result).isTrue();
+		assertThat(request.getAttribute("sessionToken")).isEqualTo(SESSION_TOKEN);
+	}
+}

--- a/src/test/java/com/kbo/config/interceptor/QueueSessionInterceptorTest.java
+++ b/src/test/java/com/kbo/config/interceptor/QueueSessionInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.kbo.config.interceptor;
 
+import static com.kbo.queue.constant.SessionKey.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -25,7 +26,7 @@ class QueueSessionInterceptorTest {
 	private MockHttpServletRequest request;
 	private MockHttpServletResponse response;
 
-	private static final String SESSION_TOKEN = "session-token";
+	private static final String TEST_SESSION_TOKEN = "session-token";
 
 	@BeforeEach
 	void setUp() {
@@ -45,8 +46,8 @@ class QueueSessionInterceptorTest {
 
 	@Test
 	void should_token_when_invalid() throws Exception {
-		request.addHeader("X-Session-Token", SESSION_TOKEN);
-		when(queueSessionRepository.getSession(SESSION_TOKEN)).thenReturn(null);
+		request.addHeader(SESSION_TOKEN_HEADER.getKey(), TEST_SESSION_TOKEN);
+		when(queueSessionRepository.getSession(TEST_SESSION_TOKEN)).thenReturn(null);
 
 		boolean result = queueSessionInterceptor.preHandle(request, response, new Object());
 
@@ -57,12 +58,13 @@ class QueueSessionInterceptorTest {
 
 	@Test
 	void should_token_when_valid() throws Exception {
-		request.addHeader("X-Session-Token", SESSION_TOKEN);
-		when(queueSessionRepository.getSession(SESSION_TOKEN)).thenReturn(QueueSessionFixture.get(SESSION_TOKEN));
+		request.addHeader(SESSION_TOKEN_HEADER.getKey(), TEST_SESSION_TOKEN);
+		when(queueSessionRepository.getSession(TEST_SESSION_TOKEN)).thenReturn(QueueSessionFixture.get(
+			TEST_SESSION_TOKEN));
 
 		boolean result = queueSessionInterceptor.preHandle(request, response, new Object());
 
 		assertThat(result).isTrue();
-		assertThat(request.getAttribute("sessionToken")).isEqualTo(SESSION_TOKEN);
+		assertThat(request.getAttribute(SESSION_TOKEN_ATTRIBUTE.getKey())).isEqualTo(TEST_SESSION_TOKEN);
 	}
 }

--- a/src/test/java/com/kbo/fixture/QueueSessionFixture.java
+++ b/src/test/java/com/kbo/fixture/QueueSessionFixture.java
@@ -1,0 +1,12 @@
+package com.kbo.fixture;
+
+import com.kbo.queue.controller.response.QueueSession;
+
+public class QueueSessionFixture {
+	public static final long GAME_ID = 1001L;
+	public static final long USER_ID = 2001L;
+
+	public static QueueSession get(String token) {
+		return new QueueSession(token, GAME_ID, USER_ID);
+	}
+}


### PR DESCRIPTION
## 작업 내용
1. 대기열 세션 검증 기능 구현
    - Interceptor 추가
        - 대기열 상태 요청시 클라이언트가 발급받은 세션 토큰을 헤더에 포함해야 요청 허용.
        - Interceptor 기반의 인증 검증 로직 추가.
        - 대기열 상태 조회 엔드포인트에 인터셉터 적용.